### PR TITLE
Create Documentation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -11,7 +11,7 @@ import datetime
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath("."))
+sys.path.insert(0, os.path.abspath(".."))
 # modules that autodock should mock
 # useful if some external dependencies are not satisfied at doc build time.
 autodoc_mock_imports = []
@@ -50,7 +50,10 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx_copybutton",
     "myst_parser",
+    "autoapi.extension",
 ]
+
+autoapi_dirs = ["../src"]
 
 autosummary_generate = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,10 @@
+[metadata]
+name = clingexplaid
+version = 1.1.0
+author = Hannes Weichelt
+author_email = hweichelt@uni-potsdam.de
+description = API to aid the development of explanation systems using clingo
+long_description = file: README.md
+long_description_content_type = text/markdown
+license = MIT
+url = https://github.com/potassco/clingo-explaid


### PR DESCRIPTION
Adding a real documentation for `clingexplaid` using sphinx

**TODOs**

+ [x] Modify configuration so that the documentation is built correctly
+ [ ] Finish the API documentation / correct type annotation
+ [ ] Create an index page and example pages
+ [ ] Implement automatic documentation workflow
    + maybe using github actions?